### PR TITLE
Fix runtime key errors and nested link error

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -74,8 +74,8 @@ export default function Stats() {
             <div className={styles.stats_container}>
                 <div className={styles.stats1_card}>
                     {stats1.map(({ number, content }, index) => (
-                        <Link to="https://github.com/conda-forge/by-the-numbers">
-                            <div className={styles.card} key={index}>
+                        <Link key={index} to="https://github.com/conda-forge/by-the-numbers">
+                            <div className={styles.card}>
                                 <h1 className="gradient_text">{number}</h1>
                                 <h3>{content}</h3>
                             </div>
@@ -84,8 +84,8 @@ export default function Stats() {
                 </div>
                 <div className={styles.stats2_card}>
                     {stats2.map(({ number, content }, index) => (
-                        <Link to="https://github.com/conda-forge/by-the-numbers">
-                            <div className={styles.card} key={index}>
+                        <Link key={index} to="https://github.com/conda-forge/by-the-numbers">
+                            <div className={styles.card}>
                                 <h1 className="gradient_text">{number}</h1>
                                 <h3>{content}</h3>
                             </div>
@@ -108,9 +108,9 @@ export default function Stats() {
                 <iframe
                     src="https://www.youtube.com/embed/EWh-BtdYE7M"
                     title="Episode 23: conda-forge - Open Source Directions hosted By Quansight"
-                    frameborder="0"
+                    frameBorder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                    allowfullscreen
+                    allowFullScreen
                 ></iframe>
             </div>
         </div>

--- a/src/components/Contributing/index.jsx
+++ b/src/components/Contributing/index.jsx
@@ -37,15 +37,7 @@ const contributing = [
         href: "https://app.element.io/#/room/#conda-forge:matrix.org",
         content: (
             <>
-                Join the{" "}
-                <a
-                    href="https://app.element.io/#/room/#conda-forge:matrix.org"
-                    target="_blank"
-                    rel="noreferrer"
-                >
-                    {" "}
-                    conda-forge community{" "}
-                </a>{" "}
+                Join the conda-forge community{" "}
                 on Element and reach out for assistance whenever needed.
             </>
         ),
@@ -63,11 +55,8 @@ export default function Contributing() {
                 <p>For a package on conda-forge, I want to ...</p>
             </div>
             {contributing.map(({ Svg, alt, title, href, content, width }, index) => (
-                <Link to={href} className={styles.linked_card}>
-                    <div
-                        className={styles.contributing_conda_forge_card}
-                        key={index}
-                        >
+                <Link to={href} key={index} className={styles.linked_card}>
+                    <div className={styles.contributing_conda_forge_card}>
                         <Svg width={width} alt={alt} role="img" />
                         <h3>{title}</h3>
                         <p>{content}</p>

--- a/src/components/Supporters/index.jsx
+++ b/src/components/Supporters/index.jsx
@@ -180,8 +180,8 @@ export default function Supporters() {
           </div>
           <div className={styles.card}>
             {financial.map(({ name, link, light, dark, width }, index) => (
-              <Link to={link}>
-                <div className={styles.cardWrapper} key={index}>
+              <Link to={link} key={index}>
+                <div className={styles.cardWrapper}>
                   <ThemedImage
                     className={styles.image}
                     alt={`${name} logo`}
@@ -205,8 +205,8 @@ export default function Supporters() {
           </div>
           <div className={styles.card}>
             {infrastructure.map(({ name, link, light, dark, width }, index) => (
-              <Link to={link}>
-                <div className={styles.cardWrapper} key={index}>
+              <Link to={link} key={index}>
+                <div className={styles.cardWrapper}>
                   <ThemedImage
                     className={styles.image}
                     alt={`${name} logo`}
@@ -230,8 +230,8 @@ export default function Supporters() {
           </div>
           <div className={styles.card}>
             {developer.map(({ name, link, light, dark, width }, index) => (
-              <Link to={link}>
-                <div className={styles.cardWrapper} key={index}>
+              <Link key={index} to={link}>
+                <div className={styles.cardWrapper}>
                   <ThemedImage
                     className={styles.image}
                     alt={`${name} logo`}


### PR DESCRIPTION
This PR fixes some runtime errors because the `key` attribute was nested after some components were linked.

It also fixes an error where a card that was a `Link` contained a nested `<a>`, which resolves down to `<a><a></a></a>` and is disalllowed.